### PR TITLE
Accounting polishing - exact times for EOSC

### DIFF
--- a/egi_notebooks_accounting/eosc.py
+++ b/egi_notebooks_accounting/eosc.py
@@ -214,7 +214,9 @@ def generate_day_metrics(
         try:
             with open(timestamp_file, "w+") as tsf:
                 timestamp_str = period_end.strftime("%Y-%m-%dT%H:%M:%SZ")
-                logging.debug(f"Writing following timestamp to '{timestamp_file}': {timestamp_str}")
+                logging.debug(
+                    f"Writing following timestamp to '{timestamp_file}': {timestamp_str}"
+                )
                 # we have open interval at the end => store the time just before the ending
                 tsf.write(timestamp_str)
         except OSError as e:

--- a/egi_notebooks_accounting/eosc.py
+++ b/egi_notebooks_accounting/eosc.py
@@ -129,9 +129,6 @@ def get_from_to_dates(args, timestamp_file):
             with open(timestamp_file, "r") as tsf:
                 try:
                     from_date = dateutil.parser.parse(tsf.read())
-                    from_date = from_date.replace(
-                        hour=0, minute=0, second=0, microsecond=0
-                    ) + timedelta(days=1)
                 except dateutil.parser.ParserError as e:
                     logging.debug(
                         f"Invalid timestamp content in '{timestamp_file}': {e}"
@@ -149,7 +146,7 @@ def get_from_to_dates(args, timestamp_file):
         # go until last minute of yesterday
         to_date = (datetime.now(timezone.utc) - timedelta(days=1)).replace(
             hour=0, minute=0, second=0, microsecond=0
-        ) + timedelta(days=1, microseconds=-1)
+        ) + timedelta(days=1)
     return from_date, to_date
 
 
@@ -166,8 +163,9 @@ def generate_day_metrics(
     logging.info(f"Generate metrics from {period_start} to {period_end}")
     metrics = {}
     # pods ending in between the reporting times
+    count = 0
     for pod in VM.select().where(
-        (VM.end_time >= period_start) & (VM.end_time <= period_end)
+        (VM.end_time >= period_start) & (VM.end_time < period_end)
     ):
         update_pod_metric(
             pod,
@@ -176,11 +174,14 @@ def generate_day_metrics(
             period_start,
             period_end,
         )
+        count = count + 1
+    logging.debug(f"=> {count} pods")
 
     # pods starting but not finished between the reporting times
+    count = 0
     for pod in VM.select().where(
-        (VM.start_time <= period_end)
-        & (VM.end_time.is_null() | (VM.end_time > period_end))
+        (VM.start_time < period_end)
+        & (VM.end_time.is_null() | (VM.end_time >= period_end))
     ):
         update_pod_metric(
             pod,
@@ -189,8 +190,10 @@ def generate_day_metrics(
             period_start,
             period_end,
         )
+        count = count + 1
+    logging.debug(f"=> {count} pods")
     period_start_str = period_start.strftime("%Y-%m-%dT%H:%M:%SZ")
-    period_end_str = period_end.strftime("%Y-%m-%dT%H:%M:%SZ")
+    period_end_str = (period_end - timedelta(seconds=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
     for (user, group), flavors in metrics.items():
         for metric_key, value in flavors.items():
             metric_data = {
@@ -210,7 +213,10 @@ def generate_day_metrics(
     if not dry_run:
         try:
             with open(timestamp_file, "w+") as tsf:
-                tsf.write(period_end.strftime("%Y-%m-%dT%H:%M:%SZ"))
+                timestamp_str = period_end.strftime("%Y-%m-%dT%H:%M:%SZ")
+                logging.debug("Writing following timestamp to '{timestamp_file}': {timestamp_str}")
+                # we have open interval at the end => store the time just before the ending
+                tsf.write(timestamp_str)
         except OSError as e:
             e = str(e)
             logging.debug("Failed to write timestamp file '{timestamp_file}': {e}")
@@ -269,8 +275,8 @@ def main(argv=None):
     logging.debug(f"Reporting from {from_date} to {to_date}")
     # repeat in 24 hour intervals
     period_start = from_date
-    while period_start <= to_date:
-        period_end = period_start + timedelta(days=1, microseconds=-1)
+    while period_start < to_date:
+        period_end = period_start + timedelta(days=1)
         generate_day_metrics(
             period_start,
             period_end,
@@ -281,7 +287,7 @@ def main(argv=None):
             installation,
             args.dry_run,
         )
-        period_start = period_end + timedelta(microseconds=1)
+        period_start = period_end
 
 
 if __name__ == "__main__":

--- a/egi_notebooks_accounting/eosc.py
+++ b/egi_notebooks_accounting/eosc.py
@@ -214,7 +214,7 @@ def generate_day_metrics(
         try:
             with open(timestamp_file, "w+") as tsf:
                 timestamp_str = period_end.strftime("%Y-%m-%dT%H:%M:%SZ")
-                logging.debug("Writing following timestamp to '{timestamp_file}': {timestamp_str}")
+                logging.debug(f"Writing following timestamp to '{timestamp_file}': {timestamp_str}")
                 # we have open interval at the end => store the time just before the ending
                 tsf.write(timestamp_str)
         except OSError as e:

--- a/egi_notebooks_accounting/tests/test_eosc.py
+++ b/egi_notebooks_accounting/tests/test_eosc.py
@@ -10,9 +10,6 @@ from .. import eosc
 from ..model import VM
 from .conftest import TestHelpers
 
-# microsecond time in hours
-MICROSECOND: float = (10**-6) / 3600
-
 
 @pytest.fixture(scope="function")
 def delete_timestamp(pytestconfig):
@@ -202,8 +199,7 @@ def test_over(pytestconfig, requests_mock, delete_timestamp) -> None:
     wall_times: list[float] = [
         2 * 3600,
     ]
-    logging.error("Known issue: missing microsecond per day")
-    results: list[float] = [0, 1.0 - MICROSECOND, 1.0, 0]
+    results: list[float] = [0, 1.0, 1.0, 0]
 
     launch_eosc(
         pytestconfig, requests_mock, from_date, start_times, wall_times, results
@@ -219,12 +215,11 @@ def test_broad(pytestconfig, requests_mock, delete_timestamp) -> None:
     wall_times: list[float] = [
         3 * 24 * 3600,
     ]
-    logging.error("Known issue: missing microsecond per day")
     results: list[float] = [
         0,
-        1.0 - MICROSECOND,
-        24.0 - MICROSECOND,
-        24.0 - MICROSECOND,
+        1.0,
+        24.0,
+        24.0,
         23.0,
         0,
     ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 dirq
-peewee
+peewee>=4
 python-dateutil
 requests


### PR DESCRIPTION
# Summary

1) Fix missing microsecond in each interval for EOSC reporting:

* using midnight for both _from_date_ and _to_date_
* sharp compare of the interval end for database
* sharp compare of the interval end in main loop
* subtract second for storing in timestamp file
* subtract second from end for EOSC reporting

2) Tune dependencies.

<!-- Describe in plain English what this PR does -->

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
#25