### PR TITLE
Do not send messages with zero CPU to APEL

### DIFF
--- a/egi_notebooks_accounting/model.py
+++ b/egi_notebooks_accounting/model.py
@@ -14,6 +14,7 @@ class VM(BaseModel):
     site = "EGI-NOTEBOOKS"
     cloud_type = "EGI Notebooks"
     cloud_compute_service = None
+    default_cpu_count = None
 
     namespace = CharField()
     primary_group = None
@@ -78,10 +79,19 @@ class VM(BaseModel):
             r["EndTime"] = int(self.end_time.timestamp())
         return r
 
+    def valid_apel(self):
+        """Enable this record for APEL
+
+        Returns true, if this record has values valid for sending to APEL.
+        """
+        return self.cpu_count != 0 or VM.default_cpu_count is not None
+
     def dump(self):
         record = []
         for k, v in self.as_dict().items():
             if v is not None:
+                if k == "CpuCount" and self.cpu_count == 0 and VM.default_cpu_count:
+                    v = self.default_cpu_count
                 record.append("{0}: {1}".format(k, v))
         return "\n".join(record)
 

--- a/egi_notebooks_accounting/pods.py
+++ b/egi_notebooks_accounting/pods.py
@@ -63,6 +63,10 @@ def main():
     VM.cloud_compute_service = os.environ.get(
         "SERVICE", config.get("cloud_compute_service", VM.cloud_compute_service)
     )
+    VM.default_cpu_count = os.environ.get(
+        "DEFAULT_CPU_COUNT",
+        config.get("default_cpu_count", VM.default_cpu_count),
+    )
     db_file = os.environ.get("NOTEBOOKS_DB", config.get("notebooks_db", None))
 
     fqans = dict(DEFAULT_FQANS)
@@ -206,7 +210,7 @@ def main():
         if spool_dir:
             queue = QueueSimple.QueueSimple(spool_dir)
             message = "APEL-cloud-message: v0.4\n" + "\n%%\n".join(
-                [pod.dump() for (uid, pod) in prom.pods.items()]
+                (pod.dump() for (uid, pod) in prom.pods.items() if pod.valid_apel())
             )
             queue.add(message)
             logging.debug("Dumped %d records to spool dir", len(prom.pods))

--- a/notebooks-accounting/templates/accounting-config.yaml
+++ b/notebooks-accounting/templates/accounting-config.yaml
@@ -21,6 +21,11 @@ data:
     {{- else }}
     # cloud_compute_service=
     {{- end }}
+    {{- if .Values.accounting.defaultCpuCount }}
+    default_cpu_count={{ .Values.accounting.defaultCpuCount }}
+    {{- else }}
+    # default_cpu_count=
+    {{- end }}
     {{- if.Values.debug }}
     verbose=1
     {{- end }}

--- a/notebooks-accounting/values.yaml
+++ b/notebooks-accounting/values.yaml
@@ -13,6 +13,13 @@ accounting:
   cloudType: EGI Notebooks
   service:
 
+  #
+  # APEL only: default CPU count to use for pods without CPU limit
+  #
+  # The empty value (default) will drop a message without CPU for APEL.
+  #
+  defaultCpuCount:
+
   # catchall FQAN for values not specified in the fqan mapping
   default_fqan: vo.notebooks.egi.eu
 


### PR DESCRIPTION
# Summary

For APEL accounting the messages with non-zero CPU are not allowed, but pod without specified limit doesn't have the CPU count.

* by default the message without CPU won't be sent
* it's possible to set the value using accounting/defaultCpuCount

<!-- Describe in plain English what this PR does -->

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
