### PR TITLE
Unit tests: add check for timeout type

### DIFF
--- a/egi_notebooks_accounting/config-tests.ini
+++ b/egi_notebooks_accounting/config-tests.ini
@@ -13,6 +13,7 @@ accounting_url=https://api.acc.eosc.example.com
 # Installation that metrics are reported for
 installation_id=test-site
 timestamp_file=eosc-accounting-test.timestamp
+timeout=120
 
 [eosc.flavors]
 # add every flavor to be reported as follows

--- a/egi_notebooks_accounting/tests/test_eosc.py
+++ b/egi_notebooks_accounting/tests/test_eosc.py
@@ -43,6 +43,7 @@ def check_request(captured, url: str, message: str) -> None:
     logging.info(f"{message} HTTP call: {captured.method} {captured.url}")
     assert captured.method == "POST", f"{message} method is POST"
     assert captured.url == url, f"{message} URL is {url}"
+    assert type(captured.timeout) == int, "timeout is of int type"
 
 
 def launch_eosc(

--- a/egi_notebooks_accounting/tests/test_eosc.py
+++ b/egi_notebooks_accounting/tests/test_eosc.py
@@ -43,7 +43,7 @@ def check_request(captured, url: str, message: str) -> None:
     logging.info(f"{message} HTTP call: {captured.method} {captured.url}")
     assert captured.method == "POST", f"{message} method is POST"
     assert captured.url == url, f"{message} URL is {url}"
-    assert type(captured.timeout) == int, "timeout is of int type"
+    assert type(captured.timeout) is int, "timeout is of int type"
 
 
 def launch_eosc(


### PR DESCRIPTION
It needs to be checked explicitly, because mock requests is more tolerant than original requests module.

# Summary

<!-- Describe in plain English what this PR does -->

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
